### PR TITLE
Avoid module name collision

### DIFF
--- a/Platforms/iOS/Supporting Files/module.modulemap
+++ b/Platforms/iOS/Supporting Files/module.modulemap
@@ -1,4 +1,4 @@
-module SRTHaishinKit [system] {
+module SRTIncludes [system] {
     header "../../../Vendor/SRT/Includes/srt.h"
     export *
 }

--- a/Platforms/macOS/Supporting Files/module.modulemap
+++ b/Platforms/macOS/Supporting Files/module.modulemap
@@ -1,4 +1,4 @@
-module SRTHaishinKit [system] {
+module SRTIncludes [system] {
     header "/usr/local/opt/srt/include/srt/srt.h"
     export *
 }

--- a/SRTHaishinKit.podspec
+++ b/SRTHaishinKit.podspec
@@ -34,6 +34,7 @@ Pod::Spec.new do |spec|
 
   spec.pod_target_xcconfig = {
     'SWIFT_INCLUDE_PATHS' => '"${PODS_TARGET_SRCROOT}/Platforms/iOS/Supporting Files"',
+    'USER_HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"/Vendor/SRT/Includes',
     'LIBRARY_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"/Vendor/SRT',
     'OTHER_LDFLAGS' => '-lsrt-iOS'
   }  

--- a/Sources/SRT/SRTConnection.swift
+++ b/Sources/SRT/SRTConnection.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SRTIncludes
 
 open class SRTConnection: NSObject {
     public enum SocketStatus: UInt32 {

--- a/Sources/SRT/SRTOutgoingSocket.swift
+++ b/Sources/SRT/SRTOutgoingSocket.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SRTIncludes
 
 final class SRTOutgoingSocket: SRTSocket {
     static let payloadSize: Int = 1316

--- a/Sources/SRT/SRTSenderStats.swift
+++ b/Sources/SRT/SRTSenderStats.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SRTIncludes
 
 public struct SRTSenderStats {
     init(_ stats: SRT_TRACEBSTATS) {

--- a/Sources/SRT/SRTSocket.swift
+++ b/Sources/SRT/SRTSocket.swift
@@ -1,6 +1,7 @@
 import Foundation
 import HaishinKit
 import Logboard
+import SRTIncludes
 
 protocol SRTSocketDelegate: AnyObject {
     func status(_ socket: SRTSocket, status: SRT_SOCKSTATUS)

--- a/Sources/SRT/SRTSocketOption.swift
+++ b/Sources/SRT/SRTSocketOption.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SRTIncludes
 
 private let enummapTranstype: [String: Any] = [
     "live": SRTT_LIVE,


### PR DESCRIPTION
Rename header packaging module to prevent collision with main module name.